### PR TITLE
Typhoeus adapter: Deal with header-less responses

### DIFF
--- a/lib/restify/adapter/typhoeus.rb
+++ b/lib/restify/adapter/typhoeus.rb
@@ -64,6 +64,8 @@ module Restify
       end
 
       def convert_headers(headers)
+        return {} unless headers
+
         headers.each_with_object({}) do |header, memo|
           memo[header[0].upcase.tr('-', '_')] = header[1]
         end


### PR DESCRIPTION
Don't ask me why, but without this, Restify broke down at this line with a very basic response from a service that, apparently, had no response headers (?).