### PR TITLE
Return response body if no processor matches

### DIFF
--- a/lib/restify/processors/base.rb
+++ b/lib/restify/processors/base.rb
@@ -36,7 +36,9 @@ module Restify
       #
       # Should be overridden in subclass.
       #
-      def load; end
+      def load
+        body
+      end
 
       # @!method body
       #

--- a/spec/restify/processors/base_spec.rb
+++ b/spec/restify/processors/base_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Restify::Processors::Base do
+  let(:context)  { Restify::Context.new('http://test.host/') }
+  let(:response) { double 'response' }
+
+  before do
+    allow(response).to receive(:links).and_return []
+    allow(response).to receive(:follow_location).and_return nil
+  end
+
+  describe 'class' do
+    describe '#accept?' do
+      subject { described_class.accept? response }
+
+      # If no other processor accepts the request, we have an explicit fallback
+      # to the base processor.
+      it 'does not accept any responses' do
+        expect(subject).to be_falsey
+      end
+    end
+  end
+
+  describe '#resource' do
+    subject { described_class.new(context, response).resource }
+    before { allow(response).to receive(:body).and_return(body) }
+
+    describe 'parsing' do
+      context 'string' do
+        let(:body) do
+          <<-BODY
+            binaryblob
+          BODY
+        end
+
+        it { is_expected.to be_a Restify::Resource }
+        it { expect(subject.response).to be response }
+        it { is_expected.to eq body }
+      end
+    end
+  end
+end

--- a/spec/restify/processors/json_spec.rb
+++ b/spec/restify/processors/json_spec.rb
@@ -30,7 +30,7 @@ describe Restify::Processors::Json do
     subject { described_class.new(context, response).resource }
     before { allow(response).to receive(:body).and_return(body) }
 
-    context 'parsing' do
+    describe 'parsing' do
       context 'single object' do
         let(:body) do
           <<-JSON
@@ -100,8 +100,7 @@ describe Restify::Processors::Json do
         end
 
         it 'parses objects as resources' do
-          expect(subject.map(&:class)).to eq \
-            [Restify::Resource, Restify::Resource]
+          expect(subject).to all(be_a(Restify::Resource))
         end
 
         it 'parses relations of resources' do


### PR DESCRIPTION
IMO, this is useful to have as default behavior, when retrieving raw data from an API (such as binary data).