### PR TITLE
Rewrite EM adapter to use connection pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ rvm:
 - '2.3.4'
 - '2.2.7'
 env:
-- ADAPTER=em-http-request
+- ADAPTER=em
+- ADAPTER=em-pooled
 - ADAPTER=typhoeus
 - ADAPTER=typhoeus-sync
 

--- a/examples/github_last.rb
+++ b/examples/github_last.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+$LOAD_PATH << File.expand_path('../../lib', __FILE__)
+
+require 'restify'
+require 'base64'
+
+require 'pry'
+
+Restify.logger.level = :debug
+
+headers = {}
+
+if ENV['AUTH']
+  auth = Base64.encode64(ENV['AUTH']).gsub(/\s+/, '').strip
+  headers['Authorization'] = "Basic #{auth}"
+end
+
+gh    = Restify.new('https://api.github.com', headers: headers).get.value!
+user  = gh.rel(:user).get(user: 'jgraichen').value!
+repos = user.rel(:repos).get.value!
+
+commits = repos.map do |repo|
+  [repo, repo.rel(:commits).get]
+end
+
+commits.map! do |repo, cmts|
+  [repo, cmts.value!]
+end
+
+commits.each do |repo, cmts|
+  head = cmts.first
+
+  puts "==== #{repo['name']} ===="
+  puts "Last commit: #{head[:sha]}"
+  puts "By #{head[:commit][:author][:name]} <#{head[:commit][:author][:email]}>"
+  puts head[:commit][:message].to_s
+  puts
+end

--- a/lib/restify/adapter/em.rb
+++ b/lib/restify/adapter/em.rb
@@ -149,7 +149,6 @@ module Restify
           include ::EventMachine::Deferrable
 
           attr_reader :request
-          attr_reader :connection
 
           def initialize(request)
             @request = request

--- a/lib/restify/adapter/em.rb
+++ b/lib/restify/adapter/em.rb
@@ -6,248 +6,114 @@ require 'em-http-request'
 module Restify
   module Adapter
     class EM < Base
-      # rubocop:disable RedundantFreeze
-      LOG_PROGNAME = 'restify.adapter.em'.freeze
-
-      # This class maintains a pool of connection objects, grouped by origin,
-      # and ensures limits for total parallel requests and per-origin requests.
-      #
-      # It does so by maintaining a list of already open, reusable connections.
-      # When any of them are checked out for usage, it counts the usages to
-      # prevent constraints being broken.
-      class Pool
-        def initialize(size: 32, per_host: 6, connect_timeout: 2, inactivity_timeout: 10)
-          @size = size
-          @per_host = per_host
-          @connect_timeout = connect_timeout
-          @inactivity_timeout = inactivity_timeout
-
-          @host = Hash.new {|h, k| h[k] = 0 }
-          @available = []
-          @queue = []
-          @used = 0
-        end
-
-        # Request a connection from the pool.
-        #
-        # Attempts to checkout a reusable connection from the pool (or create a
-        # new one). If any of the limits have been reached, the request will be
-        # put onto a queue until other connections are released.
-        #
-        # Returns a Deferrable that succeeds with a connection instance once a
-        # connection has been checked out (usually immediately).
-        #
-        # @return [Deferrable<Request>]
-        #
-        def get(request, timeout: 2)
-          defer = Deferrable.new(request)
-          defer.timeout(timeout, :timeout)
-          defer.errback { @queue.delete(defer) }
-
-          checkout(defer)
-
-          defer
-        end
-
-        # Return a connection to the pool.
-        #
-        # If there are requests in the queue (due to one of the limits having
-        # been reached), they will be given an attempt to use the released
-        # connection.
-        #
-        # If no requests are queued, the connection will be held for reuse by a
-        # subsequent request.
-        #
-        # @return [void]
-        #
-        def release(conn)
-          @available.unshift(conn) if @available.size < @size
-          @used -= 1 if @used.positive?
-
-          Restify.logger.debug(LOG_PROGNAME) do
-            "[#{conn.uri}] Released to pool (#{@available.size}/#{@used}/#{size})"
+      class Connection
+        class << self
+          def open(uri)
+            connections[uri.origin] ||= new uri.origin
           end
 
-          checkout(@queue.shift) if @queue.any? # checkout next waiting defer
-        end
-
-        alias << release
-
-        def remove(conn)
-          close(conn)
-
-          Restify.logger.debug(LOG_PROGNAME) do
-            "[#{conn.uri}] Removed from pool (#{@available.size}/#{@used}/#{size})"
+          def connections
+            @connections ||= {}
           end
-
-          checkout(@queue.shift) if @queue.any? # checkout next waiting defer
         end
 
-        # Determine the number of connections in the pool.
-        #
-        # This takes into account both reusable (idle) and used connections.
-        #
-        # @return [Integer]
-        #
-        def size
-          @available.size + @used
+        attr_reader :origin
+
+        def initialize(origin)
+          @origin   = origin
+          @pipeline = true
         end
 
-        private
-
-        def close(conn)
-          @used -= 1 if @used.positive?
-          @host[conn.uri.to_s] -= 1
-
-          conn.close
+        def requests
+          @requests ||= []
         end
 
-        def checkout(defer)
-          origin = defer.request.uri.origin
-
-          if (index = find_reusable_connection(origin))
-            defer.succeed reuse_connection(index, origin)
-          elsif can_build_new_connection?(origin)
-            defer.succeed new_connection(origin)
+        # rubocop:disable Style/IdenticalConditionalBranches
+        def call(request, writer, retried = false)
+          if requests.empty?
+            requests << [request, writer, retried]
+            process_next
           else
-            queue defer
+            requests << [request, writer, retried]
           end
         end
 
-        def find_reusable_connection(origin)
-          @available.find_index {|conn| conn.uri == origin }
+        def connection
+          @connection ||= EventMachine::HttpRequest.new(origin)
         end
 
-        def reuse_connection(index, origin)
-          @used += 1
-          @available.delete_at(index).tap do
-            Restify.logger.debug(LOG_PROGNAME) do
-              "[#{origin}] Take connection from pool " \
-                "(#{@available.size}/#{@used}/#{size})"
+        def pipeline?
+          @pipeline
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/PerceivedComplexity
+        def process_next
+          return if requests.empty?
+
+          request, writer, retried = pipeline? ? requests.shift : requests.first
+          begin
+            req = connection.send request.method.downcase,
+              keepalive: true,
+              redirects: 3,
+              path: request.uri.normalized_path,
+              query: request.uri.normalized_query,
+              body: request.body,
+              head: request.headers
+          rescue Exception => err # rubocop:disable RescueException
+            writer.reject err
+            requests.shift unless pipeline?
+            return
+          end
+
+          req.callback do
+            requests.shift unless pipeline?
+
+            writer.fulfill Response.new(
+              request,
+              req.last_effective_url,
+              req.response_header.status,
+              req.response_header,
+              req.response
+            )
+
+            if req.response_header['CONNECTION'] == 'close'
+              @connection = nil
+              @pipeline   = false
             end
+
+            process_next
           end
-        end
 
-        def new_connection(origin)
-          # If we have reached the limit, we have to throw away the oldest
-          # reusable connection in order to open a new one
-          close_oldest if size >= @size
+          req.errback do
+            requests.shift unless pipeline?
+            @connection = nil
 
-          @used += 1
-          new(origin).tap do
-            Restify.logger.debug(LOG_PROGNAME) do
-              "[#{origin}] Add new connection to pool " \
-                "(#{@available.size}/#{@used}/#{size})"
+            if pipeline?
+              EventMachine.next_tick do
+                @pipeline = false
+                call request, writer
+              end
+            elsif !retried
+              EventMachine.next_tick { call request, writer }
+            else
+              begin
+                raise "(#{req.response_header.status}) #{req.error}"
+              rescue => e
+                writer.reject e
+              end
             end
-          end
-        end
-
-        def close_oldest
-          close(@available.pop)
-
-          Restify.logger.debug(LOG_PROGNAME) do
-            "[#{origin}] Closed oldest connection in pool " \
-              "(#{@available.size}/#{@used}/#{size})"
-          end
-        end
-
-        def queue(defer)
-          Restify.logger.debug(LOG_PROGNAME) do
-            "[#{origin}] Wait for free slot " \
-              "(#{@available.size}/#{@used}/#{size})"
-          end
-
-          @queue << defer
-        end
-
-        def new(origin)
-          Restify.logger.debug(LOG_PROGNAME) do
-            "Connect to '#{origin}' " \
-            "(#{@connect_timeout}/#{@inactivity_timeout})..."
-          end
-
-          @host[origin] += 1
-
-          EventMachine::HttpRequest.new origin,
-            connect_timeout: @connect_timeout,
-            inactivity_timeout: @inactivity_timeout
-        end
-
-        def can_build_new_connection?(origin)
-          return false if @host[origin] >= @per_host
-
-          size < @size || @available.any?
-        end
-
-        class Deferrable
-          include ::EventMachine::Deferrable
-
-          attr_reader :request
-
-          def initialize(request)
-            @request = request
-          end
-
-          def succeed(connection)
-            @connection = connection
-            super
           end
         end
       end
 
-      def initialize(**kwargs)
-        @pool = Pool.new(**kwargs)
-      end
-
-      # rubocop:disable MethodLength
-      # rubocop:disable AbcSize
-      # rubocop:disable BlockLength
       def call_native(request, writer)
         next_tick do
-          defer = @pool.get(request)
-
-          defer.errback do |error|
-            writer.reject(error)
-          end
-
-          defer.callback do |conn|
-            begin
-              req = conn.send request.method.downcase,
-                keepalive: true,
-                redirects: 3,
-                path: request.uri.normalized_path,
-                query: request.uri.normalized_query,
-                body: request.body,
-                head: request.headers
-
-              req.callback do
-                writer.fulfill Response.new(
-                  request,
-                  req.last_effective_url,
-                  req.response_header.status,
-                  req.response_header,
-                  req.response
-                )
-
-                if req.response_header['CONNECTION'] == 'close'
-                  @pool.remove(conn)
-                else
-                  @pool << conn
-                end
-              end
-
-              req.errback do
-                @pool.remove(conn)
-                writer.reject(req.error)
-              end
-            rescue Exception => ex # rubocop:disable RescueException
-              @pool.remove(conn)
-              writer.reject(ex)
-            end
-          end
+          Connection.open(request.uri).call(request, writer)
         end
       end
-      # rubocop:enable all
 
       private
 

--- a/lib/restify/adapter/pooled_em.rb
+++ b/lib/restify/adapter/pooled_em.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+require 'eventmachine'
+require 'em-http-request'
+
+module Restify
+  module Adapter
+    class PooledEM < Base
+      # rubocop:disable RedundantFreeze
+      LOG_PROGNAME = 'restify.adapter.pooled-em'.freeze
+
+      # This class maintains a pool of connection objects, grouped by origin,
+      # and ensures limits for total parallel requests and per-origin requests.
+      #
+      # It does so by maintaining a list of already open, reusable connections.
+      # When any of them are checked out for usage, it counts the usages to
+      # prevent constraints being broken.
+      class Pool
+        def initialize(size: 32, per_host: 6, connect_timeout: 2, inactivity_timeout: 10)
+          @size = size
+          @per_host = per_host
+          @connect_timeout = connect_timeout
+          @inactivity_timeout = inactivity_timeout
+
+          @host = Hash.new {|h, k| h[k] = 0 }
+          @available = []
+          @queue = []
+          @used = 0
+        end
+
+        # Request a connection from the pool.
+        #
+        # Attempts to checkout a reusable connection from the pool (or create a
+        # new one). If any of the limits have been reached, the request will be
+        # put onto a queue until other connections are released.
+        #
+        # Returns a Deferrable that succeeds with a connection instance once a
+        # connection has been checked out (usually immediately).
+        #
+        # @return [Deferrable<Request>]
+        #
+        def get(request, timeout: 2)
+          defer = Deferrable.new(request)
+          defer.timeout(timeout, :timeout)
+          defer.errback { @queue.delete(defer) }
+
+          checkout(defer)
+
+          defer
+        end
+
+        # Return a connection to the pool.
+        #
+        # If there are requests in the queue (due to one of the limits having
+        # been reached), they will be given an attempt to use the released
+        # connection.
+        #
+        # If no requests are queued, the connection will be held for reuse by a
+        # subsequent request.
+        #
+        # @return [void]
+        #
+        def release(conn)
+          @available.unshift(conn) if @available.size < @size
+          @used -= 1 if @used.positive?
+
+          Restify.logger.debug(LOG_PROGNAME) do
+            "[#{conn.uri}] Released to pool (#{@available.size}/#{@used}/#{size})"
+          end
+
+          checkout(@queue.shift) if @queue.any? # checkout next waiting defer
+        end
+
+        alias << release
+
+        def remove(conn)
+          close(conn)
+
+          Restify.logger.debug(LOG_PROGNAME) do
+            "[#{conn.uri}] Removed from pool (#{@available.size}/#{@used}/#{size})"
+          end
+
+          checkout(@queue.shift) if @queue.any? # checkout next waiting defer
+        end
+
+        # Determine the number of connections in the pool.
+        #
+        # This takes into account both reusable (idle) and used connections.
+        #
+        # @return [Integer]
+        #
+        def size
+          @available.size + @used
+        end
+
+        private
+
+        def close(conn)
+          @used -= 1 if @used.positive?
+          @host[conn.uri.to_s] -= 1
+
+          conn.close
+        end
+
+        def checkout(defer)
+          origin = defer.request.uri.origin
+
+          if (index = find_reusable_connection(origin))
+            defer.succeed reuse_connection(index, origin)
+          elsif can_build_new_connection?(origin)
+            defer.succeed new_connection(origin)
+          else
+            queue defer
+          end
+        end
+
+        def find_reusable_connection(origin)
+          @available.find_index {|conn| conn.uri == origin }
+        end
+
+        def reuse_connection(index, origin)
+          @used += 1
+          @available.delete_at(index).tap do
+            Restify.logger.debug(LOG_PROGNAME) do
+              "[#{origin}] Take connection from pool " \
+                "(#{@available.size}/#{@used}/#{size})"
+            end
+          end
+        end
+
+        def new_connection(origin)
+          # If we have reached the limit, we have to throw away the oldest
+          # reusable connection in order to open a new one
+          close_oldest if size >= @size
+
+          @used += 1
+          new(origin).tap do
+            Restify.logger.debug(LOG_PROGNAME) do
+              "[#{origin}] Add new connection to pool " \
+                "(#{@available.size}/#{@used}/#{size})"
+            end
+          end
+        end
+
+        def close_oldest
+          close(@available.pop)
+
+          Restify.logger.debug(LOG_PROGNAME) do
+            "[#{origin}] Closed oldest connection in pool " \
+              "(#{@available.size}/#{@used}/#{size})"
+          end
+        end
+
+        def queue(defer)
+          Restify.logger.debug(LOG_PROGNAME) do
+            "[#{origin}] Wait for free slot " \
+              "(#{@available.size}/#{@used}/#{size})"
+          end
+
+          @queue << defer
+        end
+
+        def new(origin)
+          Restify.logger.debug(LOG_PROGNAME) do
+            "Connect to '#{origin}' " \
+            "(#{@connect_timeout}/#{@inactivity_timeout})..."
+          end
+
+          @host[origin] += 1
+
+          EventMachine::HttpRequest.new origin,
+            connect_timeout: @connect_timeout,
+            inactivity_timeout: @inactivity_timeout
+        end
+
+        def can_build_new_connection?(origin)
+          return false if @host[origin] >= @per_host
+
+          size < @size || @available.any?
+        end
+
+        class Deferrable
+          include ::EventMachine::Deferrable
+
+          attr_reader :request
+
+          def initialize(request)
+            @request = request
+          end
+
+          def succeed(connection)
+            @connection = connection
+            super
+          end
+        end
+      end
+
+      def initialize(**kwargs)
+        @pool = Pool.new(**kwargs)
+      end
+
+      # rubocop:disable MethodLength
+      # rubocop:disable AbcSize
+      # rubocop:disable BlockLength
+      def call_native(request, writer)
+        next_tick do
+          defer = @pool.get(request)
+
+          defer.errback do |error|
+            writer.reject(error)
+          end
+
+          defer.callback do |conn|
+            begin
+              req = conn.send request.method.downcase,
+                keepalive: true,
+                redirects: 3,
+                path: request.uri.normalized_path,
+                query: request.uri.normalized_query,
+                body: request.body,
+                head: request.headers
+
+              req.callback do
+                writer.fulfill Response.new(
+                  request,
+                  req.last_effective_url,
+                  req.response_header.status,
+                  req.response_header,
+                  req.response
+                )
+
+                if req.response_header['CONNECTION'] == 'close'
+                  @pool.remove(conn)
+                else
+                  @pool << conn
+                end
+              end
+
+              req.errback do
+                @pool.remove(conn)
+                writer.reject(req.error)
+              end
+            rescue Exception => ex # rubocop:disable RescueException
+              @pool.remove(conn)
+              writer.reject(ex)
+            end
+          end
+        end
+      end
+      # rubocop:enable all
+
+      private
+
+      def next_tick(&block)
+        ensure_running
+        EventMachine.next_tick(&block)
+      end
+
+      def ensure_running
+        return if EventMachine.reactor_running?
+
+        Thread.new do
+          begin
+            EventMachine.run {}
+          rescue => e
+            puts "#{self.class} -> #{e}\n#{e.backtrace.join("\n")}"
+            raise e
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,9 +14,12 @@ require 'restify'
 
 if ENV['ADAPTER']
   case ENV['ADAPTER'].to_s.downcase
-    when 'em-http-request'
+    when 'em'
       require 'restify/adapter/em'
       Restify.adapter = Restify::Adapter::EM.new
+    when 'em-pooled'
+      require 'restify/adapter/pooled_em'
+      Restify.adapter = Restify::Adapter::PooledEM.new
     when 'typhoeus'
       require 'restify/adapter/typhoeus'
       Restify.adapter = Restify::Adapter::Typhoeus.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.before(:each) do
-    Restify.logger.level = :debug
+    Restify.logger.level = Logger::DEBUG
   end
 
   config.after(:each) do


### PR DESCRIPTION
```
Previously the EM adapter tried to pipeline request that could lead to
wrongly retried requests and timeout issues in rare cases.

The new EM adapter uses a global and per origin connection pooling to issue
parallel request up to the specified limits.
```