### PR TITLE
Fix typo in header name

### DIFF
--- a/lib/restify/response.rb
+++ b/lib/restify/response.rb
@@ -134,7 +134,7 @@ module Restify
 
     # @api private
     def follow_location
-      headers['LOCATION'] || headers['CONENT_LOCATION']
+      headers['LOCATION'] || headers['CONTENT_LOCATION']
     end
 
     private


### PR DESCRIPTION
This was missed two years ago in 06b69989da634682b56c6dbb6bc912311b67f5f9.