### PR TITLE
Extract a few methods

### DIFF
--- a/lib/restify/adapter/em.rb
+++ b/lib/restify/adapter/em.rb
@@ -149,7 +149,6 @@ module Restify
           include ::EventMachine::Deferrable
 
           attr_reader :request
-          attr_reader :connection
 
           def initialize(request)
             @request = request


### PR DESCRIPTION
This extracts some methods in the new pool class.

My goals: **smaller methods** and **revealing names** to
make the logic a little easier to understand.

This should be a safe refactoring (i.e. no change in behavior),
except for one additional log message which I will explain inline.

As a nice side effect, this also gets rid of disabled Rubocop
warnings, as we are now safely in bounds.