### PR TITLE
Initialize instance variable to prevent warning

### DIFF
--- a/lib/restify/adapter/typhoeus.rb
+++ b/lib/restify/adapter/typhoeus.rb
@@ -18,6 +18,7 @@ module Restify
         @sync   = sync
         @hydra  = ::Typhoeus::Hydra.new(**options)
         @mutex  = Mutex.new
+        @thread = nil
       end
 
       def sync?


### PR DESCRIPTION
I came across this warning in one of our libraries, due to [this line](https://github.com/jgraichen/restify/blob/ec9f022a9220006e9077d803691d31de6b34e7d3/lib/restify/adapter/typhoeus.rb#L88).