### PR TITLE
Add a Msgpack processor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'em-http-request'
 gem 'em-synchrony'
 gem 'rake'
 gem 'typhoeus'
+gem 'msgpack', '~> 1.0'
 
 group :test do
   gem 'coveralls'

--- a/lib/restify.rb
+++ b/lib/restify.rb
@@ -35,9 +35,10 @@ module Restify
   module Processors
     require 'restify/processors/base'
     require 'restify/processors/json'
+    require 'restify/processors/msgpack'
   end
 
-  PROCESSORS = [Processors::Json].freeze
+  PROCESSORS = [Processors::Json, Processors::Msgpack].freeze
 
   extend Global
 end

--- a/lib/restify/context.rb
+++ b/lib/restify/context.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'restify/resource_parsing'
+
 module Restify
   # A resource context.
   #
@@ -8,6 +10,8 @@ module Restify
   # and follow links.
   #
   class Context
+    include ResourceParsing
+
     # Effective context URI.
     #
     # @return [Addressable::URI] Effective context URI.

--- a/lib/restify/processors/json.rb
+++ b/lib/restify/processors/json.rb
@@ -12,66 +12,7 @@ module Restify
     #
     class Json < Base
       def load
-        parse ::JSON.parse(body), root: true
-      end
-
-      private
-
-      # rubocop:disable Metrics/MethodLength
-      def parse(object, root: false)
-        case object
-          when Hash
-            data      = object.each_with_object({}, &method(:parse_data))
-            relations = object.each_with_object({}, &method(:parse_rels))
-
-            if self.class.indifferent_access?
-              data = with_indifferent_access(data)
-            end
-
-            if root
-              Resource.new context,
-                data: data,
-                response: response,
-                relations: relations
-            else
-              Resource.new context,
-                data: data,
-                relations: relations
-            end
-          when Array
-            object.map(&method(:parse))
-          else
-            object
-        end
-      end
-
-      def parse_data(pair, data)
-        data[pair[0].to_s] = parse pair[1]
-      end
-
-      def parse_rels(pair, relations)
-        name = case pair[0].to_s.downcase
-                 when /\A(\w+)_url\z/
-                   Regexp.last_match[1]
-                 when 'url'
-                   'self'
-                 else
-                   return
-               end
-
-        if relations.key?(name) || pair[1].nil? || pair[1].to_s =~ /\A\w*\z/
-          return
-        end
-
-        relations[name] = pair[1].to_s
-      end
-
-      def json
-        @json ||= JSON.parse(response.body)
-      end
-
-      def with_indifferent_access(data)
-        Hashie::Mash.new data
+        context.parse ::JSON.parse(body), response: response
       end
 
       class << self

--- a/lib/restify/processors/msgpack.rb
+++ b/lib/restify/processors/msgpack.rb
@@ -14,58 +14,7 @@ module Restify
     #
     class Msgpack < Base
       def load
-        parse ::MessagePack.unpack(body), root: true
-      end
-
-      private
-
-      # rubocop:disable Metrics/MethodLength
-      def parse(object, root: false)
-        case object
-          when Hash
-            data      = object.each_with_object({}, &method(:parse_data))
-            relations = object.each_with_object({}, &method(:parse_rels))
-
-            if Processors::Json.indifferent_access?
-              data = Hashie::Mash.new(data)
-            end
-
-            if root
-              Resource.new context,
-                data: data,
-                response: response,
-                relations: relations
-            else
-              Resource.new context,
-                data: data,
-                relations: relations
-            end
-          when Array
-            object.map(&method(:parse))
-          else
-            object
-        end
-      end
-
-      def parse_data(pair, data)
-        data[pair[0].to_s] = parse pair[1]
-      end
-
-      def parse_rels(pair, relations)
-        name = case pair[0].to_s.downcase
-                 when /\A(\w+)_url\z/
-                   Regexp.last_match[1]
-                 when 'url'
-                   'self'
-                 else
-                   return
-               end
-
-        if relations.key?(name) || pair[1].nil? || pair[1].to_s =~ /\A\w*\z/
-          return
-        end
-
-        relations[name] = pair[1].to_s
+        context.parse ::MessagePack.unpack(body), response: response
       end
 
       class << self

--- a/lib/restify/processors/msgpack.rb
+++ b/lib/restify/processors/msgpack.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Restify
+  #
+  module Processors
+    #
+    # Decode binary Msgpack responses.
+    #
+    # Fields matching *_url will be parsed as relations.
+    #
+    # This is intended to work as a drop-in performance
+    # upgrade for the JSON processors. The two are 100%
+    # compatible.
+    #
+    class Msgpack < Base
+      def load
+        parse ::MessagePack.unpack(body), root: true
+      end
+
+      private
+
+      # rubocop:disable Metrics/MethodLength
+      def parse(object, root: false)
+        case object
+          when Hash
+            data      = object.each_with_object({}, &method(:parse_data))
+            relations = object.each_with_object({}, &method(:parse_rels))
+
+            if Processors::Json.indifferent_access?
+              data = Hashie::Mash.new(data)
+            end
+
+            if root
+              Resource.new context,
+                data: data,
+                response: response,
+                relations: relations
+            else
+              Resource.new context,
+                data: data,
+                relations: relations
+            end
+          when Array
+            object.map(&method(:parse))
+          else
+            object
+        end
+      end
+
+      def parse_data(pair, data)
+        data[pair[0].to_s] = parse pair[1]
+      end
+
+      def parse_rels(pair, relations)
+        name = case pair[0].to_s.downcase
+                 when /\A(\w+)_url\z/
+                   Regexp.last_match[1]
+                 when 'url'
+                   'self'
+                 else
+                   return
+               end
+
+        if relations.key?(name) || pair[1].nil? || pair[1].to_s =~ /\A\w*\z/
+          return
+        end
+
+        relations[name] = pair[1].to_s
+      end
+
+      class << self
+        def accept?(response)
+          response.content_type =~ %r{\Aapplication/(x-)?msgpack($|;)}
+        end
+      end
+    end
+  end
+end

--- a/lib/restify/resource_parsing.rb
+++ b/lib/restify/resource_parsing.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Restify
+  #
+  # Parse JSON-compatible data structures (arrays, hashes, primitives...)
+  # into Restify::Resource objects.
+  #
+  module ResourceParsing
+    # rubocop:disable Metrics/MethodLength
+    def parse(object, **resource_opts)
+      case object
+        when Hash
+          data      = object.each_with_object({}, &method(:parse_data))
+          relations = object.each_with_object({}, &method(:parse_rels))
+
+          if Restify::Processors::Json.indifferent_access?
+            data = Hashie::Mash.new(data)
+          end
+
+          Resource.new self,
+            data: data,
+            relations: relations,
+            **resource_opts
+        when Array
+          object.map(&method(:parse))
+        else
+          object
+      end
+    end
+
+    def parse_data(pair, data)
+      data[pair[0].to_s] = parse pair[1]
+    end
+
+    def parse_rels(pair, relations)
+      name = case pair[0].to_s.downcase
+               when /\A(\w+)_url\z/
+                 Regexp.last_match[1]
+               when 'url'
+                 'self'
+               else
+                 return
+             end
+
+      if relations.key?(name) || pair[1].nil? || pair[1].to_s =~ /\A\w*\z/
+        return
+      end
+
+      relations[name] = pair[1].to_s
+    end
+  end
+end

--- a/spec/restify/msgpack_support_spec.rb
+++ b/spec/restify/msgpack_support_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restify do
+  describe 'when receiving MessagePack representations' do
+    before do
+      # Body maps to {"company":true,"schema":0,"subs_url":"http://localhost/base/subs"}
+      msgpack_body = [
+        '83a7636f6d70616e79c3a6736368656d6100a8737562735f75726cba687474703a2f2f6c6f63616c686f73742f626173652f73756273'
+      ].pack('H*')
+      stub_request(:get, 'http://localhost/base').to_return do
+        <<-EOF.gsub(/^ {10}/, '').rstrip.gsub('BODY', msgpack_body)
+          HTTP/1.1 200 OK
+          Content-Type: application/msgpack
+          Link: <http://localhost/base/users{/id}>; rel="users"
+          Link: <http://localhost/base/courses{/id}>; rel="courses"
+
+          BODY
+        EOF
+      end
+    end
+
+    it 'understands the API response' do
+      # msgpack has to be included manually when using Restify to parse
+      # MessagePack representations.
+      require 'msgpack'
+
+      root = Restify.new('http://localhost/base').get.value!
+
+      expect(root).to have_key 'company'
+      expect(root).to have_key 'schema'
+      expect(root.company).to eq true
+      expect(root.schema).to eq 0
+
+      # Link header relations should be parsed as usual
+      users_relation = root.rel(:users)
+      expect(users_relation).to be_a Restify::Relation
+
+      # Fields ending in _url are parsed as relation as well
+      expect(root).to have_relation 'subs'
+    end
+  end
+end


### PR DESCRIPTION
This is intended to use as a drop-in replacement for JSON. The
two encodings support the same datatypes, thus HTTP's content
negotiation can be used to tell a server to deliver a Msgpack
response (if it is capable to do so). Fully transparent to the
API consumer, this can reduce the HTTP payload by 50 percent
in some cases.

Example HTTP Request:

    GET /path HTTP/1.1
    Host: restify.de
    Accept: application/msgpack, application/json

If the server supports msgpack, it will deliver that
serialization; if it does not, it will fall back to JSON.
Restify will be able to handle both.

Spec: https://msgpack.org/
Library: https://github.com/msgpack/msgpack-ruby