### PR TITLE
Spec out and fix header precedence

### DIFF
--- a/lib/restify/context.rb
+++ b/lib/restify/context.rb
@@ -49,11 +49,12 @@ module Restify
 
     # rubocop:disable Metrics/MethodLength
     def request(method, uri, data: nil, **kwargs)
-      request = Request.new(**kwargs,
+      request = Request.new(
+        headers: headers,
+        **kwargs,
         method: method,
         uri: join(uri),
-        data: data,
-        headers: headers
+        data: data
       )
 
       ret = cache.call(request) {|req| adapter.call(req) }

--- a/lib/restify/context.rb
+++ b/lib/restify/context.rb
@@ -48,9 +48,9 @@ module Restify
     end
 
     # rubocop:disable Metrics/MethodLength
-    def request(method, uri, data: nil, **kwargs)
+    def request(method, uri, data: nil, headers: {}, **kwargs)
       request = Request.new(
-        headers: headers,
+        headers: default_headers.merge(headers),
         **kwargs,
         method: method,
         uri: join(uri),
@@ -78,7 +78,7 @@ module Restify
     def marshal_dump
       {
         uri: uri.to_s,
-        headers: headers
+        headers: default_headers
       }
     end
 
@@ -97,7 +97,7 @@ module Restify
       options[:cache] || Restify.cache
     end
 
-    def headers
+    def default_headers
       options.fetch(:headers, {})
     end
 

--- a/spec/restify/context_spec.rb
+++ b/spec/restify/context_spec.rb
@@ -13,8 +13,8 @@ describe Restify::Context do
       describe '#uri' do
         subject { super().uri }
 
-        it { expect(subject).to be_a Addressable::URI }
-        it { expect(subject).to eq context.uri }
+        it { is_expected.to be_a Addressable::URI }
+        it { is_expected.to eq context.uri }
       end
 
       describe '#adapter' do
@@ -36,11 +36,11 @@ describe Restify::Context do
       end
 
       describe '#headers' do
-        let(:kwargs) { {headers: {'Accept': 'application/json'}} }
+        let(:kwargs) { {headers: {'Accept' => 'application/json'}} }
         subject { super().options[:headers] }
 
-        it do
-          expect(subject).to eq context.send :headers
+        it 'all headers are serialized' do
+          expect(subject).to eq({'Accept' => 'application/json'})
         end
       end
     end

--- a/spec/restify/features/request_headers_spec.rb
+++ b/spec/restify/features/request_headers_spec.rb
@@ -16,6 +16,24 @@ describe Restify do
     end
   end
 
+  context 'with request headers configured for a single request' do
+    let(:context) { Restify.new('http://localhost/base') }
+
+    it 'sends the headers only for that request' do
+      root = context.get(
+        {},
+        headers: {'Accept' => 'application/msgpack, application/json'}
+      ).value!
+
+      root.rel(:self).get.value!
+
+      expect(request_stub).to have_been_requested.twice
+      expect(
+        request_stub.with(headers: {'Accept' => 'application/msgpack, application/json'})
+      ).to have_been_requested.once
+    end
+  end
+
   context 'with request headers configured for context' do
     let(:context) do
       Restify.new(

--- a/spec/restify/features/request_headers_spec.rb
+++ b/spec/restify/features/request_headers_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restify do
+  let!(:request_stub) do
+    stub_request(:get, 'http://localhost/base').to_return do
+      <<-EOF.gsub(/^ {8}/, '')
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+        Transfer-Encoding: chunked
+        Link: <http://localhost/base>; rel="self"
+
+        { "response": "success" }
+      EOF
+    end
+  end
+
+  context 'with request headers configured for context' do
+    let(:context) do
+      Restify.new(
+        'http://localhost/base',
+        headers: {'Accept' => 'application/msgpack, application/json'}
+      )
+    end
+
+    it 'sends the headers with each request' do
+      root = context.get.value!
+
+      root.rel(:self).get.value!
+
+      expect(
+        request_stub.with(headers: {'Accept' => 'application/msgpack, application/json'})
+      ).to have_been_requested.twice
+    end
+  end
+end

--- a/spec/restify/features/request_headers_spec.rb
+++ b/spec/restify/features/request_headers_spec.rb
@@ -67,5 +67,21 @@ describe Restify do
         request_stub.with(headers: {'Accept' => 'application/msgpack, application/json'})
       ).to have_been_requested.once
     end
+
+    it 'can add additional headers for single requests' do
+      root = context.get(
+        {},
+        headers: {'X-Custom' => 'foobar'}
+      ).value!
+
+      root.rel(:self).get.value!
+
+      expect(
+        request_stub.with(headers: {'Accept' => 'application/msgpack, application/json'})
+      ).to have_been_requested.twice
+      expect(
+        request_stub.with(headers: {'Accept' => 'application/msgpack, application/json', 'X-Custom' => 'foobar'})
+      ).to have_been_requested.once
+    end
   end
 end

--- a/spec/restify/features/request_headers_spec.rb
+++ b/spec/restify/features/request_headers_spec.rb
@@ -51,5 +51,21 @@ describe Restify do
         request_stub.with(headers: {'Accept' => 'application/msgpack, application/json'})
       ).to have_been_requested.twice
     end
+
+    it 'can overwrite headers for single requests' do
+      root = context.get(
+        {},
+        headers: {'Accept' => 'application/xml'}
+      ).value!
+
+      root.rel(:self).get.value!
+
+      expect(
+        request_stub.with(headers: {'Accept' => 'application/xml'})
+      ).to have_been_requested.once
+      expect(
+        request_stub.with(headers: {'Accept' => 'application/msgpack, application/json'})
+      ).to have_been_requested.once
+    end
   end
 end


### PR DESCRIPTION
This adds some feature specs (I hope you agree with that name, I did not want to clutter up the `restify_spec.rb` file, which IMO is a nice high-level example of library usage, not sweating the details).

The specs clearly define how request headers can be added both on a context level and per request. They describe the behavior that would make sense from my perspective, but requires some small fixes in how request opts are merged.

Since no previously existing tests are failing with the new behavior, I would argue this does not have to be considered as breaking backwards compatibility, we are simply changing unspecified behavior (and making it more expectable). So, no major release would be necessary.