### PR TITLE
WIP: Add promise wait timeout

### DIFF
--- a/lib/restify.rb
+++ b/lib/restify.rb
@@ -12,6 +12,7 @@ require 'addressable/template'
 module Restify
   require 'restify/error'
   require 'restify/logging'
+  require 'restify/timeout'
 
   require 'restify/promise'
   require 'restify/registry'

--- a/lib/restify/error.rb
+++ b/lib/restify/error.rb
@@ -3,24 +3,12 @@
 module Restify
   #
 
-  # A {Timeout} is raised when a request or promise times out.
-  #
-  class Timeout < StandardError
-    attr_reader :source
-
-    def initialize(source)
-      super "Operation with #{source.class} has timed out"
-
-      @source = source
-    end
-  end
-
   # A {NetworkError} is raised on unusual network exceptions such as
   # unresolvable hosts or disconnects.
   #
   class NetworkError < StandardError
     attr_reader :request
-    
+
     def initialize(request, message)
       @request = request
       super("[#{request.uri}] #{message}")

--- a/lib/restify/promise.rb
+++ b/lib/restify/promise.rb
@@ -14,13 +14,13 @@ module Restify
     end
 
     def wait(timeout = nil)
-      Timeout.new(timeout, self).tap do |t|
-        execute(t) if pending?
+      t = Timeout.new(timeout, self)
 
-        super
-        raise t if incomplete?
-        self
-      end
+      execute(t) if pending?
+
+      super
+      raise t if incomplete?
+      self
     end
 
     def then(&block)

--- a/lib/restify/promise.rb
+++ b/lib/restify/promise.rb
@@ -3,9 +3,6 @@
 module Restify
   #
   class Promise < Concurrent::IVar
-    # Default wait timeout of 30 seconds.
-    DEFAULT_TIMEOUT = 300
-
     def initialize(*dependencies, &task)
       @task         = task
       @dependencies = dependencies.flatten

--- a/lib/restify/timeout.rb
+++ b/lib/restify/timeout.rb
@@ -4,7 +4,12 @@ require 'hitimes'
 
 module Restify
   class Timeout
-    DEFAULT = 300
+    class << self
+      attr_accessor :default_timeout
+    end
+
+    # Default wait timeout of 300 seconds.
+    self.default_timeout = 300
 
     def initialize(timeout, target = nil)
       @timeout = parse_timeout(timeout)
@@ -37,7 +42,7 @@ module Restify
     end
 
     def parse_timeout(value)
-      return DEFAULT if value.nil?
+      return self.class.default_timeout if value.nil?
 
       begin
         value = Float(value)

--- a/restify.gemspec
+++ b/restify.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'typhoeus', '~> 1.3'
   spec.add_runtime_dependency 'logging', '~> 2.0'
   spec.add_runtime_dependency 'msgpack', '~> 1.2'
+  spec.add_runtime_dependency 'hitimes'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
 

--- a/spec/restify/promise_spec.rb
+++ b/spec/restify/promise_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe Restify::Promise do
+  let(:promise) { described_class.new }
+
   describe 'factory methods' do
     describe '#fulfilled' do
       subject { described_class.fulfilled(fulfill_value) }
@@ -160,6 +162,24 @@ describe Restify::Promise do
       it 'can use the dependencies to calculate the value' do
         expect(subject).to eq 17
       end
+    end
+  end
+
+  describe '#wait' do
+    it 'can time out' do
+      expect { promise.wait(0.1) }.to raise_error ::Timeout::Error
+    end
+  end
+
+  describe '#value' do
+    it 'can time out' do
+      expect { promise.value!(0.1) }.to raise_error ::Timeout::Error
+    end
+  end
+
+  describe '#value!' do
+    it 'can time out' do
+      expect { promise.value!(0.1) }.to raise_error ::Timeout::Error
     end
   end
 end

--- a/spec/restify/timeout_spec.rb
+++ b/spec/restify/timeout_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restify::Timeout do
+  let(:timer) { described_class.new(0.2) }
+
+  describe '#timeout!' do
+    context 'before having timed out' do
+      it 'do nothing' do
+        expect { timer.timeout! }.to_not raise_error
+      end
+    end
+
+    context 'after having timed out' do
+      it 'calls given block' do
+        expect { timer.timeout! }.to_not raise_error
+        sleep timer.send(:wait_interval)
+        expect { timer.timeout! }.to raise_error ::Restify::Timeout::Error
+      end
+    end
+  end
+
+  describe '#wait_on!' do
+    it 'calls block on IVar timeout' do
+      expect {
+        timer.wait_on!(Concurrent::IVar.new)
+      }.to raise_error ::Restify::Timeout::Error
+    end
+
+    it 'calls block on Promise timeout' do
+      expect {
+        timer.wait_on!(Restify::Promise.new)
+      }.to raise_error ::Restify::Timeout::Error
+    end
+
+    it 'does nothing on successful IVar' do
+      expect {
+        Concurrent::IVar.new.tap do |ivar|
+          Thread.new { ivar.set :success }
+          expect(timer.wait_on!(ivar)).to eq :success
+        end
+      }.to_not raise_error
+    end
+
+    it 'does nothing on successful Promise' do
+      expect {
+        Restify::Promise.fulfilled(:success).tap do |p|
+          expect(timer.wait_on!(p)).to eq :success
+        end
+      }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This PR introduce a timeout capability to promises defaulting to 300 seconds. The timeout is required and cannot be zero.