### PR TITLE
Add specific exceptions for typical HTTP status codes

### DIFF
--- a/lib/restify/context.rb
+++ b/lib/restify/context.rb
@@ -62,7 +62,7 @@ module Restify
         if !response.errored?
           process response
         else
-          Context.raise_response_error(response)
+          raise ResponseError.from_code(response)
         end
       end
     end
@@ -100,19 +100,6 @@ module Restify
 
     def default_headers
       options.fetch(:headers, {})
-    end
-
-    class << self
-      def raise_response_error(response)
-        case response.code
-          when 400...500
-            raise ClientError.new(response)
-          when 500...600
-            raise ServerError.new(response)
-          else
-            raise "Unknown response code: #{response.code}"
-        end
-      end
     end
   end
 end

--- a/lib/restify/error.rb
+++ b/lib/restify/error.rb
@@ -22,6 +22,16 @@ module Restify
 
     def self.from_code(response)
       case response.code
+        when 400
+          BadRequest.new(response)
+        when 401
+          Unauthorized.new(response)
+        when 404
+          NotFound.new(response)
+        when 406
+          NotAcceptable.new(response)
+        when 422
+          UnprocessableEntity.new(response)
         when 400...500
           ClientError.new(response)
         when 500...600
@@ -76,4 +86,15 @@ module Restify
   # A {ServerError} will be raised when a response has a
   # 5XX status code.
   class ServerError < ResponseError; end
+
+  ###
+  # CONCRETE SUBCLASSES FOR TYPICAL STATUS CODES
+  #
+  # This makes it easy to rescue specific expected error types.
+
+  class BadRequest < ClientError; end
+  class Unauthorized < ClientError; end
+  class NotFound < ClientError; end
+  class NotAcceptable < ClientError; end
+  class UnprocessableEntity < ClientError; end
 end

--- a/lib/restify/error.rb
+++ b/lib/restify/error.rb
@@ -20,6 +20,17 @@ module Restify
   class ResponseError < StandardError
     attr_reader :response
 
+    def self.from_code(response)
+      case response.code
+        when 400...500
+          ClientError.new(response)
+        when 500...600
+          ServerError.new(response)
+        else
+          raise "Unknown response code: #{response.code}"
+      end
+    end
+
     def initialize(response)
       @response = response
       super "#{response.message} (#{response.code}) for `#{response.uri}':\n" \

--- a/spec/restify/features/response_errors.rb
+++ b/spec/restify/features/response_errors.rb
@@ -20,6 +20,22 @@ describe Restify do
   describe 'Error handling' do
     subject(:request) { Restify.new('http://localhost/base').get.value! }
 
+    context 'for 400 status codes' do
+      let(:http_status) { '400 Bad Request' }
+
+      it 'throws a ClientError exception' do
+        expect { request }.to raise_error Restify::ClientError
+      end
+    end
+
+    context 'for 401 status codes' do
+      let(:http_status) { '401 Unauthorized' }
+
+      it 'throws a ClientError exception' do
+        expect { request }.to raise_error Restify::ClientError
+      end
+    end
+
     context 'for 404 status codes' do
       let(:http_status) { '404 Not Found' }
 
@@ -28,8 +44,24 @@ describe Restify do
       end
     end
 
-    context 'for any other 4xx status codes' do
+    context 'for 406 status codes' do
+      let(:http_status) { '406 Not Acceptable' }
+
+      it 'throws a ClientError exception' do
+        expect { request }.to raise_error Restify::ClientError
+      end
+    end
+
+    context 'for 422 status codes' do
       let(:http_status) { '422 Unprocessable Entity' }
+
+      it 'throws a ClientError exception' do
+        expect { request }.to raise_error Restify::ClientError
+      end
+    end
+
+    context 'for any other 4xx status codes' do
+      let(:http_status) { '415 Unsupported Media Type' }
 
       it 'throws a ClientError exception' do
         expect { request }.to raise_error Restify::ClientError

--- a/spec/restify/features/response_errors.rb
+++ b/spec/restify/features/response_errors.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restify do
+  let!(:request_stub) do
+    stub_request(:get, 'http://localhost/base')
+      .to_return do
+      <<-RESPONSE.gsub(/^ {8}/, '')
+        HTTP/1.1 #{http_status}
+        Content-Length: 333
+        Transfer-Encoding: chunked
+        Link: <http://localhost/other>; rel="neat"
+      RESPONSE
+    end
+  end
+
+  let(:http_status) { '200 OK' }
+
+  describe 'Error handling' do
+    subject(:request) { Restify.new('http://localhost/base').get.value! }
+
+    context 'for 404 status codes' do
+      let(:http_status) { '404 Not Found' }
+
+      it 'throws a ClientError exception' do
+        expect { request }.to raise_error Restify::ClientError
+      end
+    end
+
+    context 'for any other 4xx status codes' do
+      let(:http_status) { '422 Unprocessable Entity' }
+
+      it 'throws a ClientError exception' do
+        expect { request }.to raise_error Restify::ClientError
+      end
+    end
+
+    context 'for any 5xx status codes' do
+      let(:http_status) { '500 Internal Server Error' }
+
+      it 'throws a ServerError exception' do
+        expect { request }.to raise_error Restify::ServerError
+      end
+    end
+  end
+end

--- a/spec/restify/features/response_errors.rb
+++ b/spec/restify/features/response_errors.rb
@@ -23,16 +23,16 @@ describe Restify do
     context 'for 400 status codes' do
       let(:http_status) { '400 Bad Request' }
 
-      it 'throws a ClientError exception' do
-        expect { request }.to raise_error Restify::ClientError
+      it 'throws a BadRequest exception' do
+        expect { request }.to raise_error Restify::BadRequest
       end
     end
 
     context 'for 401 status codes' do
       let(:http_status) { '401 Unauthorized' }
 
-      it 'throws a ClientError exception' do
-        expect { request }.to raise_error Restify::ClientError
+      it 'throws an Unauthorized exception' do
+        expect { request }.to raise_error Restify::Unauthorized
       end
     end
 
@@ -40,30 +40,30 @@ describe Restify do
       let(:http_status) { '404 Not Found' }
 
       it 'throws a ClientError exception' do
-        expect { request }.to raise_error Restify::ClientError
+        expect { request }.to raise_error Restify::NotFoundError
       end
     end
 
     context 'for 406 status codes' do
       let(:http_status) { '406 Not Acceptable' }
 
-      it 'throws a ClientError exception' do
-        expect { request }.to raise_error Restify::ClientError
+      it 'throws a NotAcceptable exception' do
+        expect { request }.to raise_error Restify::NotAcceptable
       end
     end
 
     context 'for 422 status codes' do
       let(:http_status) { '422 Unprocessable Entity' }
 
-      it 'throws a ClientError exception' do
-        expect { request }.to raise_error Restify::ClientError
+      it 'throws a UnprocessableEntity exception' do
+        expect { request }.to raise_error Restify::UnprocessableEntity
       end
     end
 
     context 'for any other 4xx status codes' do
       let(:http_status) { '415 Unsupported Media Type' }
 
-      it 'throws a ClientError exception' do
+      it 'throws a generic ClientError exception' do
         expect { request }.to raise_error Restify::ClientError
       end
     end
@@ -71,7 +71,7 @@ describe Restify do
     context 'for any 5xx status codes' do
       let(:http_status) { '500 Internal Server Error' }
 
-      it 'throws a ServerError exception' do
+      it 'throws a generic ServerError exception' do
         expect { request }.to raise_error Restify::ServerError
       end
     end


### PR DESCRIPTION
This means specific errors can be handled directly by rescuing specific exception classes, instead of rescuing e.g. `Restify::ClientError` and then checking the exception's `code` or `status`.

**Open questions:**
- Naming? I'd like to avoid the `...Error` suffix, if possible, but that would probably mean we need a new namespace. Can subclasses be nested in their own parent class' namespace?
- Which error types do we want to handle? (It's easy to add new types later.) I went through our services and added those that we handle in a special way anywhere.