### PR TITLE
Fix promise resolution with empty array of deps

### DIFF
--- a/lib/restify/promise.rb
+++ b/lib/restify/promise.rb
@@ -7,6 +7,13 @@ module Restify
       @dependencies = dependencies.flatten
 
       super(&nil)
+
+      # When dependencies were passed in, but none are left after flattening,
+      # then we don't have to wait for explicit dependencies or resolution
+      # through a writer.
+      if !@task && @dependencies.empty? && dependencies.any?
+        complete true, [], nil
+      end
     end
 
     def wait(timeout = nil)

--- a/spec/restify/promise_spec.rb
+++ b/spec/restify/promise_spec.rb
@@ -163,6 +163,13 @@ describe Restify::Promise do
         expect(subject).to eq 17
       end
     end
+
+    # Nobody does this explicitly, but it can happen when the array of
+    # dependencies is built dynamically.
+    context 'with an empty array of dependencies and without task' do
+      subject { described_class.new([]).value! }
+      it { is_expected.to eq [] }
+    end
   end
 
   describe '#wait' do


### PR DESCRIPTION
When building a promise with a dynamic array of dependencies, this array
can sometimes be empty. This behavior was currently not specified. We
expect this promise to return an empty array, which would be consistent
with the return value for multiple input dependencies (an array with one
result per input promise).

There is one other case when this situation (no task, no dependencies)
can happen: external promise resolution using a `Writer` object, e.g.
through `Restify::Promise.fulfilled`. To differentiate these cases, we
explicitly check for one or more empty arrays being passed in.