### PR TITLE
Fix hierarchy of exception classes

### DIFF
--- a/lib/restify/error.rb
+++ b/lib/restify/error.rb
@@ -102,7 +102,7 @@ module Restify
   # failing or not available.
   #
   # This can be used to catch "common" gateway responses.
-  class GatewayError < ResponseError; end
+  class GatewayError < ServerError; end
 
   ###
   # CONCRETE SUBCLASSES FOR TYPICAL STATUS CODES


### PR DESCRIPTION
The `GatewayError` class was recently introduced (in 3053cf8) to
group together status codes 502, 503 and 504.

It broke the previous expectation of all 5xx status codes raising
an instance of `ServerError` (or one of its children). This is
restored with this commit.