### PR TITLE
Custom request bodies / media types

### DIFF
--- a/lib/restify/request.rb
+++ b/lib/restify/request.rb
@@ -36,7 +36,7 @@ module Restify
       @timeout = opts.fetch(:timeout, 300)
       @headers = opts.fetch(:headers, {})
 
-      @headers.merge! 'Content-Type' => 'application/json' if json?
+      @headers['Content-Type'] ||= 'application/json' if json?
     end
 
     def body

--- a/lib/restify/request.rb
+++ b/lib/restify/request.rb
@@ -34,18 +34,26 @@ module Restify
       @uri     = opts.fetch(:uri) { raise ArgumentError.new ':uri required.' }
       @data    = opts.fetch(:data, nil)
       @timeout = opts.fetch(:timeout, 300)
-      @headers = opts.fetch(:headers, {}).merge \
-        'Content-Type' => 'application/json'
+      @headers = opts.fetch(:headers, {})
+
+      @headers.merge! 'Content-Type' => 'application/json' if json?
     end
 
     def body
-      @body ||= begin
-        JSON.dump(data) unless data.nil?
-      end
+      @body ||= json? ? JSON.dump(@data) : @data
     end
 
     def to_s
       "#<#{self.class} #{method.upcase} #{uri}>"
+    end
+
+    private
+
+    def json?
+      return false if @data.nil?
+      return false if @data.is_a? String
+
+      true
     end
   end
 end

--- a/spec/restify/features/request_bodies_spec.rb
+++ b/spec/restify/features/request_bodies_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restify do
+  let!(:request_stub) do
+    stub_request(:post, 'http://localhost/base')
+      .to_return do
+      <<-RESPONSE.gsub(/^ {8}/, '')
+        HTTP/1.1 200 OK
+        Content-Length: 333
+        Transfer-Encoding: chunked
+        Link: <http://localhost/other>; rel="neat"
+      RESPONSE
+    end
+  end
+
+  describe 'Request body' do
+    subject { Restify.new('http://localhost/base').post(body, {}, {headers: headers}).value! }
+    let(:headers) { {} }
+
+    context 'with JSON-like data structures' do
+      let(:body) { {a: 'b', c: 'd'} }
+
+      it 'is serialized as JSON' do
+        subject
+
+        expect(
+          request_stub.with(body: '{"a":"b","c":"d"}')
+        ).to have_been_requested
+      end
+
+      it 'gets a JSON media type for free' do
+        subject
+
+        expect(
+          request_stub.with(headers: {'Content-Type' => 'application/json'})
+        ).to have_been_requested
+      end
+    end
+
+    context 'with strings' do
+      let(:body) { 'a=b&c=d' }
+
+      it 'is sent as provided' do
+        subject
+
+        expect(
+          request_stub.with(body: 'a=b&c=d')
+        ).to have_been_requested
+      end
+
+      it 'does not get a JSON media type' do
+        subject
+
+        expect(
+          request_stub.with {|req| req.headers['Content-Type'].nil? }
+        ).to have_been_requested
+      end
+    end
+  end
+end

--- a/spec/restify/features/request_bodies_spec.rb
+++ b/spec/restify/features/request_bodies_spec.rb
@@ -37,6 +37,18 @@ describe Restify do
           request_stub.with(headers: {'Content-Type' => 'application/json'})
         ).to have_been_requested
       end
+
+      context 'with overridden media type' do
+        let(:headers) { {'Content-Type' => 'application/vnd.api+json'} }
+
+        it 'respects the override' do
+          subject
+
+          expect(
+            request_stub.with(headers: {'Content-Type' => 'application/vnd.api+json'})
+          ).to have_been_requested
+        end
+      end
     end
 
     context 'with strings' do
@@ -56,6 +68,18 @@ describe Restify do
         expect(
           request_stub.with {|req| req.headers['Content-Type'].nil? }
         ).to have_been_requested
+      end
+
+      context 'with overridden media type' do
+        let(:headers) { {'Content-Type' => 'application/x-www-form-urlencoded'} }
+
+        it 'respects the override' do
+          subject
+
+          expect(
+            request_stub.with(headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
+          ).to have_been_requested
+        end
       end
     end
   end


### PR DESCRIPTION
This lets us overwrite the `Content-Type` of requests.
Furthermore, passing in a string for a request's `data` will now bypass the JSON serialization.

Hat tip @Adsidera for your input. :grin: See you soon!