### PR TITLE
Replace request stubs with real stub server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :test do
   gem 'codecov', require: false
   gem 'simplecov', require: false
 
+  gem 'puma'
   gem 'rspec', '~> 3.0'
   gem 'rspec-collection_matchers'
   gem 'rubocop', '~> 1.7.0'

--- a/spec/restify/features/head_requests_spec.rb
+++ b/spec/restify/features/head_requests_spec.rb
@@ -4,20 +4,19 @@ require 'spec_helper'
 
 describe Restify do
   let!(:request_stub) do
-    stub_request(:head, 'http://localhost/base')
+    stub_request(:head, 'http://stubserver/base')
       .with(query: hash_including({}))
       .to_return do
-      <<-RESPONSE.gsub(/^ {8}/, '')
+      <<~HTTP
         HTTP/1.1 200 OK
         Content-Length: 333
-        Transfer-Encoding: chunked
-        Link: <http://localhost/other>; rel="neat"
-      RESPONSE
+        Link: <http://localhost:9292/other>; rel="neat"
+      HTTP
     end
   end
 
   describe 'HEAD requests' do
-    subject { Restify.new('http://localhost/base').head(params).value! }
+    subject { Restify.new('http://localhost:9292/base').head(params).value! }
     let(:params) { {} }
 
     it 'returns a resource with access to headers' do

--- a/spec/restify/features/request_headers_spec.rb
+++ b/spec/restify/features/request_headers_spec.rb
@@ -4,20 +4,19 @@ require 'spec_helper'
 
 describe Restify do
   let!(:request_stub) do
-    stub_request(:get, 'http://localhost/base').to_return do
-      <<-RESPONSE.gsub(/^ {8}/, '')
+    stub_request(:get, "http://stubserver/base").to_return do
+      <<~HTTP
         HTTP/1.1 200 OK
         Content-Type: application/json
-        Transfer-Encoding: chunked
-        Link: <http://localhost/base>; rel="self"
+        Link: <http://localhost:9292/base>; rel="self"
 
         { "response": "success" }
-      RESPONSE
+      HTTP
     end
   end
 
   context 'with request headers configured for a single request' do
-    let(:context) { Restify.new('http://localhost/base') }
+    let(:context) { Restify.new('http://localhost:9292/base') }
 
     it 'sends the headers only for that request' do
       root = context.get(
@@ -37,7 +36,7 @@ describe Restify do
   context 'with request headers configured for context' do
     let(:context) do
       Restify.new(
-        'http://localhost/base',
+        'http://localhost:9292/base',
         headers: {'Accept' => 'application/msgpack, application/json'}
       )
     end

--- a/spec/restify/features/response_errors_spec.rb
+++ b/spec/restify/features/response_errors_spec.rb
@@ -4,21 +4,13 @@ require 'spec_helper'
 
 describe Restify do
   let!(:request_stub) do
-    stub_request(:get, 'http://localhost/base')
-      .to_return do
-      <<-RESPONSE.gsub(/^ {8}/, '')
-        HTTP/1.1 #{http_status}
-        Content-Length: 333
-        Transfer-Encoding: chunked
-        Link: <http://localhost/other>; rel="neat"
-      RESPONSE
-    end
+    stub_request(:get, 'http://stubserver/base').to_return(status: http_status)
   end
 
   let(:http_status) { '200 OK' }
 
   describe 'Error handling' do
-    subject(:request) { Restify.new('http://localhost/base').get.value! }
+    subject(:request) { Restify.new('http://localhost:9292/base').get.value! }
 
     context 'for 400 status codes' do
       let(:http_status) { '400 Bad Request' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rspec'
-require 'webmock/rspec'
+require 'rspec/collection_matchers'
 
 require 'simplecov'
 SimpleCov.start do
@@ -34,17 +34,13 @@ if ENV['ADAPTER']
   end
 end
 
-require 'webmock/rspec'
-require 'rspec/collection_matchers'
-require 'em-synchrony'
-
-Dir[File.expand_path('spec/support/**/*.rb')].sort.each {|f| require f }
+require_relative 'support/stub_server.rb'
 
 RSpec.configure do |config|
   config.order = 'random'
 
   config.before(:suite) do
-    ::Restify::Timeout.default_timeout = 2
+    ::Restify::Timeout.default_timeout = 0.1
   end
 
   config.before(:each) do

--- a/spec/support/stub_server.rb
+++ b/spec/support/stub_server.rb
@@ -92,7 +92,7 @@ RSpec.configure do |config|
 
     # Net::HTTP adapter must be enabled, otherwise webmock fails to create mock
     # responses from raw strings.
-    WebMock.enable!(except: %i[em_http_request typhoeus])
+    WebMock.disable!(except: %i[net_http])
   end
 
   config.around(:each) do |example|

--- a/spec/support/stub_server.rb
+++ b/spec/support/stub_server.rb
@@ -43,7 +43,7 @@ module Stub
       # If no stub matched `nil` is returned.
       if response
         status = response.status
-        status = status.to_s.split(' ', 2) if !status.is_a?(Array)
+        status = status.to_s.split(' ', 2) unless status.is_a?(Array)
         status = Integer(status[0])
 
         [status, response.headers || {}, [response.body.to_s]]
@@ -72,7 +72,7 @@ module Stub
   end
 
   class << self
-    def start_server! # rubocop:disable Metrics/MethodLength
+    def start_server!
       @server = ::Puma::Server.new(Handler.new)
       @server.add_tcp_listener('localhost', 9292)
 

--- a/spec/support/stub_server.rb
+++ b/spec/support/stub_server.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'puma'
+require 'rack'
+require 'webmock'
+require 'webmock/rspec/matchers'
+
+module Stub
+  # This Rack application matches the request received from rack against the
+  # webmock stub database and returns the response.
+  #
+  # A custom server name is used to
+  #   1) has a stable name without a dynamic port for easier `#stub_request`
+  #      calls, and
+  #   2) to ensure no actual request is intercepted (they are send to
+  #      `localhost:<port>`).
+  #
+  # If no stub is found a special HTTP 599 error code will be returned.
+  class Handler
+    def call(env) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      signature = WebMock::RequestSignature.new(
+        env['REQUEST_METHOD'].downcase,
+        "http://stubserver#{env['REQUEST_URI']}"
+      )
+
+      # Extract request headers from rack env. Most header should start with
+      # `HTTP_` but at least content type is present as `CONTENT_TYPE`.
+      headers = {}
+      env.each_pair do |key, value|
+        case key
+          when /^HTTP_(.*)$/, /^(CONTENT_.*)$/
+            headers[Regexp.last_match(1)] = value
+        end
+      end
+
+      # Read request body from socket into string
+      signature.body = env['rack.input'].read
+      signature.headers = headers
+
+      WebMock::RequestRegistry.instance.requested_signatures.put(signature)
+      response = ::WebMock::StubRegistry.instance.response_for_request(signature)
+
+      # If no stub matched `nil` is returned.
+      if response
+        status = response.status
+        status = status.to_s.split(' ', 2) if !status.is_a?(Array)
+        status = Integer(status[0])
+
+        [status, response.headers || {}, [response.body.to_s]]
+      else
+        # Return special HTTP 599 with the error message that would normally
+        # appear on missing stubs.
+        [599, {}, [WebMock::NetConnectNotAllowedError.new(signature).message]]
+      end
+    end
+  end
+
+  class Exception < ::StandardError; end
+
+  # Inject into base adapter to have HTTP 599 (missing stub) error raised as an
+  # extra exception, not just a server error.
+  module Patch
+    def call(request)
+      super.then do |response|
+        next response unless response.code == 599
+
+        raise ::Stub::Exception.new(response.body)
+      end
+    end
+
+    ::Restify::Adapter::Base.prepend(self)
+  end
+
+  class << self
+    def start_server! # rubocop:disable Metrics/MethodLength
+      @server = ::Puma::Server.new(Handler.new)
+      @server.add_tcp_listener('localhost', 9292)
+
+      Thread.new do
+        @server.run
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include WebMock::API
+  config.include WebMock::Matchers
+
+  config.before(:suite) do
+    Stub.start_server!
+
+    # Net::HTTP adapter must be enabled, otherwise webmock fails to create mock
+    # responses from raw strings.
+    WebMock.enable!(except: %i[em_http_request typhoeus])
+  end
+
+  config.around(:each) do |example|
+    example.run
+    WebMock.reset!
+  end
+end


### PR DESCRIPTION
This CL replaces the inline webmock stubs with real requests agains a stub server. The stub server still uses webmock for matching incoming requests.

This should make testing much more reliable and realistic especially for eventmachine-based adapters. Webmock previously patched all HTTP client adapters but that introduced subtile behavior changes with concurrency or scheduling of threads or callbacks. Using the stub server and real communication the adapter behave much more like in production including possible concurrent requests or expected threading behavior.