### PR TITLE
Support HTTP 429 (Too many Requests)

### DIFF
--- a/lib/restify/error.rb
+++ b/lib/restify/error.rb
@@ -34,6 +34,8 @@ module Restify
           Gone.new(response)
         when 422
           UnprocessableEntity.new(response)
+        when 429
+          TooManyRequests.new(response)
         when 400...500
           ClientError.new(response)
         when 500
@@ -120,6 +122,8 @@ module Restify
   class Gone < ClientError; end
 
   class UnprocessableEntity < ClientError; end
+
+  class TooManyRequests < ClientError; end
 
   class InternalServerError < ServerError; end
 

--- a/lib/restify/error.rb
+++ b/lib/restify/error.rb
@@ -123,7 +123,20 @@ module Restify
 
   class UnprocessableEntity < ClientError; end
 
-  class TooManyRequests < ClientError; end
+  class TooManyRequests < ClientError
+    def retry_after
+      case response.headers['RETRY_AFTER']
+        when /^\d+$/
+          DateTime.now + Rational(response.headers['RETRY_AFTER'].to_i, 86_400)
+        when String
+          begin
+            DateTime.httpdate response.headers['RETRY_AFTER']
+          rescue ArgumentError
+            nil
+          end
+      end
+    end
+  end
 
   class InternalServerError < ServerError; end
 

--- a/spec/restify/features/response_errors_spec.rb
+++ b/spec/restify/features/response_errors_spec.rb
@@ -52,6 +52,14 @@ describe Restify do
       end
     end
 
+    context 'for 429 status codes' do
+      let(:http_status) { '429 Too Many Requests' }
+
+      it 'throws a TooManyRequests exception' do
+        expect { request }.to raise_error Restify::TooManyRequests
+      end
+    end
+
     context 'for any other 4xx status codes' do
       let(:http_status) { '415 Unsupported Media Type' }
 

--- a/spec/restify/features/response_errors_spec.rb
+++ b/spec/restify/features/response_errors_spec.rb
@@ -4,10 +4,12 @@ require 'spec_helper'
 
 describe Restify do
   let!(:request_stub) do
-    stub_request(:get, 'http://stubserver/base').to_return(status: http_status)
+    stub_request(:get, 'http://stubserver/base')
+      .to_return(status: http_status, headers: headers)
   end
 
   let(:http_status) { '200 OK' }
+  let(:headers) { {} }
 
   describe 'Error handling' do
     subject(:request) { Restify.new('http://localhost:9292/base').get.value! }
@@ -57,6 +59,52 @@ describe Restify do
 
       it 'throws a TooManyRequests exception' do
         expect { request }.to raise_error Restify::TooManyRequests
+      end
+
+      describe 'the exception' do
+        subject(:exception) do
+          exception = nil
+          begin
+            request
+          rescue Restify::TooManyRequests => e
+            exception = e
+          end
+          exception
+        end
+
+        context 'by default' do
+          it 'does not know when to retry again' do
+            expect(exception.retry_after).to be_nil
+          end
+        end
+
+        context 'with Retry-After header containing seconds' do
+          let(:headers) { {'Retry-After' => '120'} }
+
+          it 'determines the date correctly' do
+            now = DateTime.now
+            lower = now + Rational(119, 86_400)
+            upper = now + Rational(121, 86_400)
+
+            expect(exception.retry_after).to be_between(lower, upper)
+          end
+        end
+
+        context 'with Retry-After header containing HTTP date' do
+          let(:headers) { {'Retry-After' => 'Sun, 13 Mar 2033 13:03:33 GMT'} }
+
+          it 'parses the date correctly' do
+            expect(exception.retry_after.to_s).to eq '2033-03-13T13:03:33+00:00'
+          end
+        end
+
+        context 'with Retry-After header containing invalid date string' do
+          let(:headers) { {'Retry-After' => 'tomorrow 12:00:00'} }
+
+          it 'does not know when to retry again' do
+            expect(exception.retry_after).to be_nil
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Our conversation prompted me to add this natively. Even with support for parsing the `Retry-After` header. 🎉 

I hope you like it. 😊 