### PR TITLE
feat: Support for OpenTelemetry tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### New
 
 - Support for Ruby 3.4
+- Experimental support for OpenTelemetry tracing
 
 ### Changes
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,3 @@ group :development do
   gem 'redcarpet', platform: :ruby
   gem 'yard'
 end
-
-group :development, :test do
-  gem 'pry', platforms: :mri
-  gem 'pry-byebug', platforms: :mri
-end

--- a/examples/github_last.rb
+++ b/examples/github_last.rb
@@ -5,8 +5,6 @@ $LOAD_PATH << File.expand_path('../lib', __dir__)
 require 'restify'
 require 'base64'
 
-require 'pry'
-
 headers = {}
 
 if ENV['LOGGING']

--- a/examples/github_thread.rb
+++ b/examples/github_thread.rb
@@ -3,7 +3,6 @@
 $LOAD_PATH << File.expand_path('../lib', __dir__)
 
 require 'restify'
-require 'pry'
 
 if ENV['LOGGING']
   Logging.logger.root.add_appenders Logging.appenders.stdout

--- a/lib/restify/adapter/base.rb
+++ b/lib/restify/adapter/base.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require 'restify/adapter/telemetry'
+
 module Restify
   module Adapter
     class Base
+      prepend Telemetry
+
       def call(request)
         Promise.create do |writer|
           call_native request, writer

--- a/lib/restify/adapter/telemetry.rb
+++ b/lib/restify/adapter/telemetry.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'opentelemetry'
+require 'opentelemetry/common'
+
+module Restify
+  module Adapter
+    module Telemetry
+      def call(request)
+        method = request.method.to_s.upcase
+        uri = URI.parse(request.uri)
+        name = "#{method} #{uri.scheme}://#{uri.host}:#{uri.port}"
+
+        attributes = {
+          'http.request.method' => method,
+          'server.address' => uri.host,
+          'server.port' => uri.port,
+          'url.full' => uri.to_s,
+          'url.scheme' => uri.scheme,
+        }
+
+        span = tracer.start_span(name, attributes:, kind: :client)
+        OpenTelemetry::Trace.with_span(span) do
+          OpenTelemetry.propagation.inject(request.headers)
+
+          super.tap do |x|
+            x.add_observer do |_, response, err|
+              if response
+                span.set_attribute('http.response.status_code', response&.code)
+                span.status = OpenTelemetry::Trace::Status.error unless (100..399).cover?(response&.code)
+              end
+
+              span.status = OpenTelemetry::Trace::Status.error(err) if err
+
+              span.finish
+            end
+          end
+        end
+      end
+
+      protected
+
+      def tracer
+        Telemetry.tracer
+      end
+
+      class << self
+        def tracer
+          @tracer ||= OpenTelemetry.tracer_provider.tracer('restify', Restify::VERSION.to_s)
+        end
+      end
+    end
+  end
+end

--- a/restify.gemspec
+++ b/restify.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hitimes'
   spec.add_dependency 'logging', '~> 2.0'
   spec.add_dependency 'msgpack', '~> 1.2'
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-common'
   spec.add_dependency 'rack'
   spec.add_dependency 'typhoeus', '~> 1.3'
 


### PR DESCRIPTION
This PR adds native support for tracing with OpenTelemetry, including
proper context propagation into the adapter background thread and
improve support for upstream Ethon instrumentation.