### PR TITLE
feat: Strict keyword handling in request methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   `#post`, `#put`, and `#patch` still take an optional first positional data/body argument. Change `post(body, {}, {headers: ...})` to `post(body, headers: ...)`.
 
+  `#get`, `#head`, and `#delete` accept a hash as the first positional argument, which is merged with `params:`. Therefore, passing parameters as data works too: `get({id: 1})`.
+
 ### Fixes
 
 ### Breaks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changes
 
+- Strict keyword handling for request methods
+
+  All request methods take parameters and headers as explicit keyword arguments, not as secondary arguments anymore. Change e.g. `get({}, {headers: ...})` into `get(headers: ...)`, and `head(params)` to `head(params:)`.
+
+  `#post`, `#put`, and `#patch` still take an optional first positional data/body argument. Change `post(body, {}, {headers: ...})` to `post(body, headers: ...)`.
+
 ### Fixes
 
 ### Breaks

--- a/README.md
+++ b/README.md
@@ -69,15 +69,13 @@ repositories = client.rel(:repository)
 This gets us the relation named `repository` that we can request now. The usual HTTP methods are available on a relation:
 
 ```ruby
-def get(params:, **)
+def get(params, params:, headers:, **)
+def head(params, params:, headers:, **)
+def delete(params, params:, headers:, **)
 
-def delete(params:, **)
-
-def post(data = nil, params:, **)
-
-def put(data = nil, params:, **)
-
-def patch(data = nil, params:, **)
+def put(data = nil, params:, headers:, **)
+def post(data = nil, params:, headers:, **)
+def patch(data = nil, params:, headers:, **)
 ```
 
 URL templates can define some parameters such as `{owner}` or `{repo}`. They will be expanded from the `params` given to the HTTP method.
@@ -85,7 +83,7 @@ URL templates can define some parameters such as `{owner}` or `{repo}`. They wil
 Now send a GET request with some parameters to request a specific repository:
 
 ```ruby
-repo = repositories.get(owner: 'jgraichen', repo: 'restify').value
+repo = repositories.get({owner: 'jgraichen', repo: 'restify'}).value
 ```
 
 Now fetch a list of commits for this repo and get this first one:

--- a/README.md
+++ b/README.md
@@ -69,25 +69,15 @@ repositories = client.rel(:repository)
 This gets us the relation named `repository` that we can request now. The usual HTTP methods are available on a relation:
 
 ```ruby
-    def get(params = {})
-      request :get, nil, params
-    end
+def get(params:, **)
 
-    def delete(params = {})
-      request :delete, nil, params
-    end
+def delete(params:, **)
 
-    def post(data = {}, params = {})
-      request :post, data, params
-    end
+def post(data = nil, params:, **)
 
-    def put(data = {}, params = {})
-      request :put, data, params
-    end
+def put(data = nil, params:, **)
 
-    def patch(data = {}, params = {})
-      request :patch, data, params
-    end
+def patch(data = nil, params:, **)
 ```
 
 URL templates can define some parameters such as `{owner}` or `{repo}`. They will be expanded from the `params` given to the HTTP method.

--- a/examples/github_last.rb
+++ b/examples/github_last.rb
@@ -17,7 +17,7 @@ if (token = ENV.fetch('GITHUB_TOKEN', nil))
 end
 
 gh    = Restify.new('https://api.github.com', headers:).get.value!
-user  = gh.rel(:user).get(user: 'jgraichen').value!
+user  = gh.rel(:user).get({user: 'jgraichen'}).value!
 repos = user.rel(:repos).get.value!
 
 commits = repos.map do |repo|

--- a/examples/github_thread.rb
+++ b/examples/github_thread.rb
@@ -14,7 +14,7 @@ if (token = ENV.fetch('GITHUB_TOKEN', nil))
 end
 
 gh   = Restify.new('https://api.github.com', headers:).get.value
-repo = gh.rel(:repository).get(owner: 'jgraichen', repo: 'restify').value
+repo = gh.rel(:repository).get({owner: 'jgraichen', repo: 'restify'}).value
 cmt  = repo.rel(:commits).get.value.first
 
 puts "Last commit: #{cmt['sha']}"

--- a/lib/restify/registry.rb
+++ b/lib/restify/registry.rb
@@ -7,7 +7,7 @@ module Restify
     end
 
     def store(name, uri, **opts)
-      @registry[name] = Context.new uri, **opts
+      @registry[name] = Context.new(uri, **opts)
     end
 
     def fetch(name)

--- a/lib/restify/relation.rb
+++ b/lib/restify/relation.rb
@@ -23,28 +23,31 @@ module Restify
       context.request(method, expand(params), **opts)
     end
 
-    def get(**opts)
-      request(**opts, method: :get)
+    def get(data = {}, params: {}, **opts)
+      request(**opts, method: :get, params: data.merge(params))
     end
 
-    def head(**opts)
-      request(**opts, method: :head)
+    def head(data = {}, params: {}, **opts)
+      request(**opts, method: :head, params: data.merge(params))
     end
 
-    def delete(**opts)
-      request(**opts, method: :head)
+    def delete(data = {}, params: {}, **opts)
+      request(**opts, method: :delete, params: data.merge(params))
     end
 
     def post(data = nil, **opts)
-      request(**opts, method: :post, data: data)
+      opts[:data] = data unless opts.key?(:data)
+      request(**opts, method: :post)
     end
 
     def put(data = nil, **opts)
-      request(**opts, method: :put, data: data)
+      opts[:data] = data unless opts.key?(:data)
+      request(**opts, method: :put)
     end
 
     def patch(data = nil, **opts)
-      request(**opts, method: :patch, data: data)
+      opts[:data] = data unless opts.key?(:data)
+      request(**opts, method: :patch)
     end
 
     def ==(other)

--- a/lib/restify/relation.rb
+++ b/lib/restify/relation.rb
@@ -19,32 +19,32 @@ module Restify
       @template = Addressable::Template.new template
     end
 
-    def request(method, data, params, opts = {})
-      context.request method, expand(params), **opts, data:
+    def request(method:, params: {}, **opts)
+      context.request(method, expand(params), **opts)
     end
 
-    def get(params = {}, opts = {})
-      request :get, nil, params, opts
+    def get(**opts)
+      request(**opts, method: :get)
     end
 
-    def head(params = {}, opts = {})
-      request :head, nil, params, opts
+    def head(**opts)
+      request(**opts, method: :head)
     end
 
-    def delete(params = {}, opts = {})
-      request :delete, nil, params, opts
+    def delete(**opts)
+      request(**opts, method: :head)
     end
 
-    def post(data = {}, params = {}, opts = {})
-      request :post, data, params, opts
+    def post(data = nil, **opts)
+      request(**opts, method: :post, data: data)
     end
 
-    def put(data = {}, params = {}, opts = {})
-      request :put, data, params, opts
+    def put(data = nil, **opts)
+      request(**opts, method: :put, data: data)
     end
 
-    def patch(data = {}, params = {}, opts = {})
-      request :patch, data, params, opts
+    def patch(data = nil, **opts)
+      request(**opts, method: :patch, data: data)
     end
 
     def ==(other)

--- a/lib/restify/request.rb
+++ b/lib/restify/request.rb
@@ -29,12 +29,12 @@ module Restify
     #
     attr_reader :timeout
 
-    def initialize(opts = {})
-      @method  = opts.fetch(:method, :get).downcase
-      @uri     = opts.fetch(:uri) { raise ArgumentError.new ':uri required.' }
-      @data    = opts.fetch(:data, nil)
-      @timeout = opts.fetch(:timeout, 300)
-      @headers = opts.fetch(:headers, {})
+    def initialize(uri:, method: :get, data: nil, timeout: 300, headers: {})
+      @uri     = uri
+      @method  = method.to_s.downcase
+      @data    = data
+      @timeout = timeout
+      @headers = headers
 
       @headers['Content-Type'] ||= 'application/json' if json?
     end

--- a/spec/restify/features/head_requests_spec.rb
+++ b/spec/restify/features/head_requests_spec.rb
@@ -16,7 +16,7 @@ describe Restify do
   end
 
   describe 'HEAD requests' do
-    subject(:value) { Restify.new('http://localhost:9292/base').head(params).value! }
+    subject(:value) { Restify.new('http://localhost:9292/base').head(params:).value! }
 
     let(:params) { {} }
 

--- a/spec/restify/features/request_bodies_spec.rb
+++ b/spec/restify/features/request_bodies_spec.rb
@@ -13,7 +13,7 @@ describe Restify do
   end
 
   describe 'Request body' do
-    subject(:value) { Restify.new('http://localhost:9292/base').post(body, {}, {headers:}).value! }
+    subject(:value) { Restify.new('http://localhost:9292/base').post(body, headers:).value! }
 
     let(:headers) { {} }
 

--- a/spec/restify/features/request_errors_spec.rb
+++ b/spec/restify/features/request_errors_spec.rb
@@ -8,7 +8,7 @@ describe Restify, adapter: 'Restify::Adapter::Typhoeus' do
   end
 
   describe 'Timeout' do
-    subject(:request) { Restify.new('http://localhost:9292/base').get({}, timeout: 0.1).value! }
+    subject(:request) { Restify.new('http://localhost:9292/base').get(timeout: 0.1).value! }
 
     it 'throws a network error' do
       expect { request }.to raise_error Restify::NetworkError do |error|

--- a/spec/restify/features/request_headers_spec.rb
+++ b/spec/restify/features/request_headers_spec.rb
@@ -20,8 +20,7 @@ describe Restify do
 
     it 'sends the headers only for that request' do
       root = context.get(
-        {},
-        {headers: {'Accept' => 'application/msgpack, application/json'}},
+        headers: {'Accept' => 'application/msgpack, application/json'},
       ).value!
 
       root.rel(:self).get.value!
@@ -53,8 +52,7 @@ describe Restify do
 
     it 'can overwrite headers for single requests' do
       root = context.get(
-        {},
-        {headers: {'Accept' => 'application/xml'}},
+        headers: {'Accept' => 'application/xml'},
       ).value!
 
       root.rel(:self).get.value!
@@ -69,8 +67,7 @@ describe Restify do
 
     it 'can add additional headers for single requests' do
       root = context.get(
-        {},
-        {headers: {'X-Custom' => 'foobar'}},
+        headers: {'X-Custom' => 'foobar'},
       ).value!
 
       root.rel(:self).get.value!

--- a/spec/restify_spec.rb
+++ b/spec/restify_spec.rb
@@ -138,7 +138,7 @@ describe Restify do
         end
 
         # Let's try again.
-        created_user = users_relation.post(name: 'John Smith').value!
+        created_user = users_relation.post({name: 'John Smith'}).value!
 
         # The server returns a 201 Created response with the created
         # resource.


### PR DESCRIPTION
All request methods on Relation accept parameters and headers as keyword arguments. This clearly separates them from any data. They continue to take either `params` or `data` as a positional argument too, to support shorter call invocations.

This needs changes to users, for example:

```ruby
get({}, {headers: ...})         ->  get(headers: ...)
head(id: 1)                     ->  head({id: 1})
delete(params, {headers: ...})  ->  delete(params, headers: ...)
```

These can stay:

```ruby
get(params)
head(params)
delete(params)
```


The methods `#post`, `#put`, and `#patch` still take an optional first positional data/body argument:

```ruby
put(body)                       ->  put(body)
post(body, {}, {headers: ...})  ->  post(body, headers: ...)
patch(body, {q: 1})             ->  post(body, params: {q: 1})
```