### PR TITLE
fix: WebMock instrumentation with Typhoeus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixes
 
+- Restore compatibility with WebMocks Typhoeus instrumentation
+- Catch WebMock exception and bubble them to the request promises
+
 ### Breaks
 
 ## 2.0.0 - (2025-02-14)

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ group :test do
   gem 'rspec-collection_matchers'
   gem 'webmock'
 
+  gem 'opentelemetry-instrumentation-ethon'
+  gem 'opentelemetry-sdk'
+
   gem 'rubocop-config', github: 'jgraichen/my-rubocop', tag: 'v13'
 end
 

--- a/spec/restify/features/opentelemetry_spec.rb
+++ b/spec/restify/features/opentelemetry_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restify do
+  subject(:echo) { resource.data }
+
+  let(:resource) { Restify.new('http://localhost:9292/echo').get.value! }
+
+  before do
+    expect(OTLE_EXPORTER.finished_spans).to be_empty
+  end
+
+  describe 'OpenTelemetry' do
+    it 'adds propagation header' do
+      expect(echo).to have_key('HTTP_TRACEPARENT')
+    end
+
+    it 'adds spans' do
+      resource
+
+      spans = OTLE_EXPORTER.finished_spans
+      expect(spans.size).to eq 2
+
+      spans[1].tap do |span|
+        expect(span.instrumentation_scope.name).to eq 'restify'
+        expect(span.instrumentation_scope.version).to eq Restify::VERSION.to_s
+        expect(span.attributes).to eq({
+          'http.request.method' => 'GET',
+          'http.response.status_code' => 200,
+          'server.address' => 'localhost',
+          'server.port' => 9292,
+          'url.full' => 'http://localhost:9292/echo',
+          'url.scheme' => 'http',
+        })
+      end
+
+      # Latest span has to be from the Ethon instrumentation and must
+      # have the Restify span as a parent.
+      spans[0].tap do |span|
+        expect(span.instrumentation_scope.name).to match(/Ethon/)
+        expect(span.parent_span_id).to eq spans[1].span_id
+      end
+    end
+  end
+end

--- a/spec/restify/features/webmock_spec.rb
+++ b/spec/restify/features/webmock_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restify do
+  before do
+    WebMock.enable!
+  end
+
+  after do
+    WebMock.disable!(except: %i[net_http])
+  end
+
+  describe 'WebMock' do
+    subject(:resource) { Restify.new('http://www.example.com/base').get.value! }
+
+    it 'can stub requests' do
+      stub_request(:any, 'http://www.example.com/base')
+
+      expect(resource.response.status).to eq(:ok)
+    end
+
+    it 'raises error for not stubbed requests' do
+      expect { resource }.to raise_error WebMock::NetConnectNotAllowedError
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ if ENV['ADAPTER']
   end
 end
 
+require_relative 'support/opentelemetry'
 require_relative 'support/stub_server'
 
 RSpec.configure do |config|

--- a/spec/support/opentelemetry.rb
+++ b/spec/support/opentelemetry.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'opentelemetry/sdk'
+require 'opentelemetry/instrumentation/ethon'
+
+OTLE_EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(OTLE_EXPORTER)
+
+OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
+  c.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)
+  c.add_span_processor span_processor
+
+  c.use 'OpenTelemetry::Instrumentation::Ethon'
+end
+
+RSpec.configure do |config|
+  config.around do |example|
+    OTLE_EXPORTER.reset
+
+    original_propagation = OpenTelemetry.propagation
+    propagator = OpenTelemetry::Trace::Propagation::TraceContext.text_map_propagator
+    OpenTelemetry.propagation = propagator
+
+    example.run
+  ensure
+    OpenTelemetry.propagation = original_propagation
+  end
+end

--- a/spec/support/stub_server.rb
+++ b/spec/support/stub_server.rb
@@ -18,6 +18,10 @@ module Stub
   # If no stub is found a special HTTP 599 error code will be returned.
   class Handler
     def call(env)
+      if env['REQUEST_URI'] == '/echo'
+        return [200, {'content-type': 'application/json'}, [env.to_json]]
+      end
+
       signature = WebMock::RequestSignature.new(
         env['REQUEST_METHOD'].downcase,
         "http://stubserver#{env['REQUEST_URI']}",


### PR DESCRIPTION
The WebMock instrumentation for Typhoeus::Hydra didn't work anymore with the patches Restify added to its Hydra object to keep track of the OTEL context. The patched removed the callback behavior in Hydra that was used by WebMock.

This commit fixes that by keeping tracking of the OTEL context with the Typhoeus request itself, restoring the context when Hydra actually adds the request. Otherwise, the same code is called as before and callbacks will work again too.

The WebMock support is further expanded to catch exceptions and bubble them up to the promise, e.g. when request ain't allowed. Before, they only stopped the background thread, and promises run into a timeout. Now, whenever an exception is raised to a specific request, it will instead reject the Promise of that request.

Lastly, the commit adds specs for the WebMock integration as well as the working OTEL context propagation.