### PR TITLE
Restore literal false in parameter expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixes
 
+- Restore literal false in parameter expansion (#68)
+
 ### Breaks
 
 ## 2.0.1 - (2025-02-16)

--- a/lib/restify/relation.rb
+++ b/lib/restify/relation.rb
@@ -113,8 +113,10 @@ module Restify
 
     def extract!(params)
       @template.variables.each_with_object({}) do |var, hash|
-        if (value = params.delete(var) { params.delete(var.to_sym) { nil } })
-          hash[var] = value
+        if params.key?(var)
+          hash[var] = params.delete(var)
+        elsif params.key?(var.to_sym)
+          hash[var] = params.delete(var.to_sym)
         end
       end
     end

--- a/lib/restify/relation.rb
+++ b/lib/restify/relation.rb
@@ -113,10 +113,12 @@ module Restify
 
     def extract!(params)
       @template.variables.each_with_object({}) do |var, hash|
+        sym = var.to_sym
         if params.key?(var)
           hash[var] = params.delete(var)
-        elsif params.key?(var.to_sym)
-          hash[var] = params.delete(var.to_sym)
+        end
+        if params.key?(sym)
+          hash[sym] = params.delete(sym)
         end
       end
     end

--- a/spec/restify/relation_spec.rb
+++ b/spec/restify/relation_spec.rb
@@ -63,7 +63,7 @@ describe Restify::Relation do
       let(:pattern) { '/resource{?abc}' }
       let(:params) { {abc: nil} }
 
-      it { expect(expanded.to_s).to eq 'http://test.host/resource?abc' }
+      it { expect(expanded.to_s).to eq 'http://test.host/resource' }
     end
 
     context 'with false query parameter' do

--- a/spec/restify/relation_spec.rb
+++ b/spec/restify/relation_spec.rb
@@ -38,7 +38,7 @@ describe Restify::Relation do
     context 'with false' do
       let(:params) { {id: false} }
 
-      it { expect(expanded.to_s).to eq 'http://test.host/resource/' }
+      it { expect(expanded.to_s).to eq 'http://test.host/resource/false' }
     end
 
     context 'with true' do

--- a/spec/restify/relation_spec.rb
+++ b/spec/restify/relation_spec.rb
@@ -59,6 +59,27 @@ describe Restify::Relation do
       it { expect(expanded.to_s).to eq 'http://test.host/resource/1,2' }
     end
 
+    context 'with nil query parameter' do
+      let(:pattern) { '/resource{?abc}' }
+      let(:params) { {abc: nil} }
+
+      it { expect(expanded.to_s).to eq 'http://test.host/resource?abc' }
+    end
+
+    context 'with false query parameter' do
+      let(:pattern) { '/resource{?abc}' }
+      let(:params) { {abc: false} }
+
+      it { expect(expanded.to_s).to eq 'http://test.host/resource?abc=false' }
+    end
+
+    context 'with true query parameter' do
+      let(:pattern) { '/resource{?abc}' }
+      let(:params) { {abc: true} }
+
+      it { expect(expanded.to_s).to eq 'http://test.host/resource?abc=true' }
+    end
+
     context 'with unknown additional query parameter' do
       let(:pattern) { '/resource{?a,b}' }
       let(:params) { {a: 1, b: 2, c: 3} }

--- a/spec/restify/relation_spec.rb
+++ b/spec/restify/relation_spec.rb
@@ -140,6 +140,38 @@ describe Restify::Relation do
 
       it { expect { expanded }.to raise_exception TypeError, /Can't convert Hash into String./ }
     end
+
+    context 'with string-keyed params' do
+      context 'with value' do
+        let(:params) { {'id' => 1} }
+
+        it { expect(expanded.to_s).to eq 'http://test.host/resource/1' }
+      end
+    end
+
+    context 'with mixed-keyed params' do
+      context 'non-overlapping' do
+        let(:params) { {'id' => 1, q: 2} }
+
+        it { expect(expanded.to_s).to eq 'http://test.host/resource/1?q=2' }
+      end
+
+      context 'overlapping (1)' do
+        let(:params) { {'id' => 1, id: 2} }
+
+        it 'prefers symbol value' do
+          expect(expanded.to_s).to eq 'http://test.host/resource/2'
+        end
+      end
+
+      context 'overlapping (2)' do
+        let(:params) { {id: 2, 'id' => 1} }
+
+        it 'prefers symbol value' do
+          expect(expanded.to_s).to eq 'http://test.host/resource/2'
+        end
+      end
+    end
   end
 
   shared_examples 'non-data-request' do |method|


### PR DESCRIPTION
Restore putting literal false values into query params. Previously,
literal false values were ignored from template expansion, resulting in
unexpected queries:

```rb
get(params: {public: true, hidden: false})
# => /?public=true
```

This commit changes the parameter expansion to include `false` as
a literal value. This does include `false` in path params, which will
result in e.g. `/resource/false` now, but that seems "more correct" too.

<hr>

The previous implementation is handling expected query parameters with a `false` value in an unintended manner. Rather than appending the parameter as expected, it is omitted. This is in contrast to parameters not included in the pattern, where a `false` value would be appended.

In a test-driven development fashion, this commit adds a failing test first and thereby allows working on the bug more easily.

<hr>

The bug investigated (and covered through the test) has led to real-world failures. Let me take an example from openHPI. Consider a course that is hidden:

<img width="1028" alt="Bildschirmfoto 2025-05-19 um 12 50 38" src="https://github.com/user-attachments/assets/c5bc83ee-5aee-4a92-abeb-a3c8fab6430a" />

In a public export for MOOChub, this course should not be shown:
```rb
def courses
  @courses ||= course_api
    .rel(:courses)
    .get({
      public: true,
      exclude_external: true,
      hidden: false,
      alphabetic: true,
      page:,
      active_after: 3.years.ago.to_date.iso8601,
    }).value!
end
```

The request made to the respective service, however, does not include the `hidden` query parameter:
![Bildschirmfoto 2025-05-19 um 12 55 31](https://github.com/user-attachments/assets/422cd63f-12f5-4e23-9fa2-ba7f4a11445d)

Consequently, the course is shown on <moochub.org>:
![Bildschirmfoto 2025-05-19 um 12 56 34](https://github.com/user-attachments/assets/7f276f22-477a-4d3a-99e3-eec8d50e3b8f)
